### PR TITLE
Handle comma separated decimals in mpstat output

### DIFF
--- a/pr2_computer_monitor/scripts/cpu_monitor.py
+++ b/pr2_computer_monitor/scripts/cpu_monitor.py
@@ -423,10 +423,10 @@ def check_mpstat(core_count = -1):
                 continue
 
             cpu_name = '%d' % (num_cores)
-            idle = lst[idle_col]
-            user = lst[3]
-            nice = lst[4]
-            system = lst[5]
+            idle = lst[idle_col].replace(',', '.')
+            user = lst[3].replace(',', '.')
+            nice = lst[4].replace(',', '.')
+            system = lst[5].replace(',', '.')
             
             core_level = 0
             usage = float(user) + float(nice)


### PR DESCRIPTION
Workaround replacing commas resulting from a German like locale with dots. Previously given message: "mpstat Exception: invalid literal for float(): 0,00"

Actually using some locale setting might be better, but I have no time and hardware to check side effects, and this workaround should be free of such.
