### PR TITLE
Rename joy node

### DIFF
--- a/pr2_bringup/pr2.launch
+++ b/pr2_bringup/pr2.launch
@@ -18,7 +18,7 @@
   <include file="$(find pr2_controller_manager)/controller_manager.launch" />
 
   <!-- PS3 joystick for A2 servers -->
-  <node machine="c2" pkg="joy" type="joy_node" name="joy" >
+  <node machine="c2" pkg="joy" type="joy_node" name="joy_node" >
     <param name="deadzone" value="0.12" />
     <param name="dev" value="/etc/ros/sensors/ps3joy" />
     <param name="autorepeat_rate" value="10" />


### PR DESCRIPTION
When remapping /joy, not only topic but also NODE is renamed.
This is because topic name and node name is the same.

```
<launch>
  <group>
    <remap from="/joy" to="/joy_org"/>
    <include file="$(pr2_bringup)/pr2.launch" />
  </group>
</launch>
```

However parameters are not remapped and don't work.
