### PR TITLE
Compile pr2_run_stop_auto_restart after generating pr2_msgs c++ codes

### DIFF
--- a/pr2_run_stop_auto_restart/CMakeLists.txt
+++ b/pr2_run_stop_auto_restart/CMakeLists.txt
@@ -15,6 +15,7 @@ catkin_package()
 
 add_executable(run_stop_auto_restart src/run_stop_auto_restart.cpp)
 target_link_libraries(run_stop_auto_restart ${catkin_LIBRARIES})
+add_dependencies(run_stop_auto_restart pr2_msgs_gencpp)
 
 install(TARGETS run_stop_auto_restart
    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})


### PR DESCRIPTION
Need to guarantee to compile pr2_run_stop_auto_restart after generating pr2_msgs headers
