### PR TITLE
Depends on impmitool

### DIFF
--- a/pr2_computer_monitor/package.xml
+++ b/pr2_computer_monitor/package.xml
@@ -23,7 +23,7 @@
   <run_depend>pr2_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
-
+  <run_depend>impitool</run_depend>
 
 
 


### PR DESCRIPTION
pr2_computer_monitor should depend on ipmitool
https://github.com/PR2/pr2_robot/blob/hydro-devel/pr2_computer_monitor/scripts/cpu_monitor.py#L71

cc: @orikuma 
