### PR TITLE
C2 seperation

### DIFF
--- a/pr2_bringup/CMakeLists.txt
+++ b/pr2_bringup/CMakeLists.txt
@@ -22,4 +22,5 @@ install(PROGRAMS ${PYTHON_SCRIPTS}
 install(FILES
    pr2.launch
    pr2_recalibrate.launch
+   pr2-c2.launch
    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/pr2_bringup/pr2-c2.launch
+++ b/pr2_bringup/pr2-c2.launch
@@ -1,0 +1,45 @@
+<launch>
+
+      <!-- Battery Monitor -->
+      <node machine="c2" pkg="ocean_battery_driver" type="ocean_server"  name="ocean_server"$
+        <param name="number_of_ports" type="int" value="4" />
+        <param name="port0" type="string" value="/etc/ros/sensors/battery0" />
+        <param name="port1" type="string" value="/etc/ros/sensors/battery1" />
+        <param name="port2" type="string" value="/etc/ros/sensors/battery2" />
+        <param name="port3" type="string" value="/etc/ros/sensors/battery3" />
+        <param name="debug_level" type="int" value="0" />
+      </node>
+  
+      <!-- Base Laser -->
+      <node machine="c2" pkg="hokuyo_node" type="hokuyo_node" name="base_hokuyo_node" args="sc$
+        <param name="port" type="string" value="/etc/ros/sensors/base_hokuyo" />
+        <param name="frame_id" type="string" value="base_laser_link" />
+        <param name="min_ang" type="double" value="-2.2689" />
+        <param name="max_ang" type="double" value="2.2689" />
+        <param name="skip" type="int" value="1" />
+        <param name="intensity" value="false" />
+      </node>
+ 
+      <node  machine="c2" pkg="hokuyo_node" type="hokuyo_node" name="tilt_hokuyo_node" args=$
+        <param name="port" type="string" value="/etc/ros/sensors/tilt_hokuyo" />
+        <param name="frame_id" type="string" value="laser_tilt_link" />
+        <param name="min_ang" type="double" value="-0.829" />
+        <param name="max_ang" type="double" value="0.829" />
+        <param name="skip" type="int" value="1" />
+        <param name="intensity" value="true" />
+      </node>
+
+
+      <!-- Disk usage monitoring script monitors HD temperature, usage on diagnostics -->
+      <node pkg="pr2_computer_monitor" name="two_hd_monitor" type="hd_monitor.py" args="--diag-hostname=c2" machine="c2"/>
+
+      <node pkg="pr2_computer_monitor" name="two_cpu_monitor" type="cpu_monitor.py" args="--diag-hostname=c2" machine="c2" >
+        <param name="check_core_temps" type="bool" value="False" />
+        <param name="enforce_clock_speed" type="bool" value="False" />
+      </node>
+
+      <!-- NTP monitoring script reports clock sync on diagnostics -->
+      <node pkg="pr2_computer_monitor" name="ntp_c2" type="ntp_monitor.py" args="c1 --diag-hostname=c2" machine="c2"/>
+
+
+</launch>

--- a/pr2_bringup/pr2-c2.launch
+++ b/pr2_bringup/pr2-c2.launch
@@ -1,7 +1,7 @@
 <launch>
 
       <!-- Battery Monitor -->
-      <node machine="c2" pkg="ocean_battery_driver" type="ocean_server"  name="ocean_server"$
+      <node machine="c2" pkg="ocean_battery_driver" type="ocean_server"  name="ocean_server" respawn="true">
         <param name="number_of_ports" type="int" value="4" />
         <param name="port0" type="string" value="/etc/ros/sensors/battery0" />
         <param name="port1" type="string" value="/etc/ros/sensors/battery1" />
@@ -11,7 +11,7 @@
       </node>
   
       <!-- Base Laser -->
-      <node machine="c2" pkg="hokuyo_node" type="hokuyo_node" name="base_hokuyo_node" args="sc$
+      <node machine="c2" pkg="hokuyo_node" type="hokuyo_node" name="base_hokuyo_node" args="scan:=base_scan">
         <param name="port" type="string" value="/etc/ros/sensors/base_hokuyo" />
         <param name="frame_id" type="string" value="base_laser_link" />
         <param name="min_ang" type="double" value="-2.2689" />
@@ -21,7 +21,7 @@
       </node>
  
       <!-- Tilt laser -->
-      <node  machine="c2" pkg="hokuyo_node" type="hokuyo_node" name="tilt_hokuyo_node" args=$
+      <node  machine="c2" pkg="hokuyo_node" type="hokuyo_node" name="tilt_hokuyo_node" args="scan:=tilt_scan">
         <param name="port" type="string" value="/etc/ros/sensors/tilt_hokuyo" />
         <param name="frame_id" type="string" value="laser_tilt_link" />
         <param name="min_ang" type="double" value="-0.829" />

--- a/pr2_bringup/pr2-c2.launch
+++ b/pr2_bringup/pr2-c2.launch
@@ -20,6 +20,7 @@
         <param name="intensity" value="false" />
       </node>
  
+      <!-- Tilt laser -->
       <node  machine="c2" pkg="hokuyo_node" type="hokuyo_node" name="tilt_hokuyo_node" args=$
         <param name="port" type="string" value="/etc/ros/sensors/tilt_hokuyo" />
         <param name="frame_id" type="string" value="laser_tilt_link" />
@@ -33,6 +34,8 @@
       <!-- Disk usage monitoring script monitors HD temperature, usage on diagnostics -->
       <node pkg="pr2_computer_monitor" name="two_hd_monitor" type="hd_monitor.py" args="--diag-hostname=c2" machine="c2"/>
 
+
+      <!-- Two CPU monitor -->
       <node pkg="pr2_computer_monitor" name="two_cpu_monitor" type="cpu_monitor.py" args="--diag-hostname=c2" machine="c2" >
         <param name="check_core_temps" type="bool" value="False" />
         <param name="enforce_clock_speed" type="bool" value="False" />
@@ -40,6 +43,7 @@
 
       <!-- NTP monitoring script reports clock sync on diagnostics -->
       <node pkg="pr2_computer_monitor" name="ntp_c2" type="ntp_monitor.py" args="c1 --diag-hostname=c2" machine="c2"/>
+
 
 
 </launch>

--- a/pr2_bringup/pr2.launch
+++ b/pr2_bringup/pr2.launch
@@ -42,44 +42,8 @@
   <!-- Power Board Control Node -->
   <node name="power_board" pkg="pr2_power_board" type="power_node2" args="--address=10.68.0.50" respawn="true"/>
 
-  <!-- Battery Monitor -->
- <!--  <group if="$(arg c2)"> 
-      <node machine="c2" pkg="ocean_battery_driver" type="ocean_server"  name="ocean_server" respawn="true">
-        <param name="number_of_ports" type="int" value="4" />
-        <param name="port0" type="string" value="/etc/ros/sensors/battery0" />
-        <param name="port1" type="string" value="/etc/ros/sensors/battery1" />
-        <param name="port2" type="string" value="/etc/ros/sensors/battery2" />
-        <param name="port3" type="string" value="/etc/ros/sensors/battery3" />
-        <param name="debug_level" type="int" value="0" />
-      </node>
-  </group> -->
-
   <node pkg="power_monitor" type="power_monitor"  name="power_monitor" respawn="true"/>
   
-  <!-- Base Laser -->
-  <!-- <group if="$(arg c2)">
-    <node machine="c2" pkg="hokuyo_node" type="hokuyo_node" name="base_hokuyo_node" args="scan:=base_scan">
-        <param name="port" type="string" value="/etc/ros/sensors/base_hokuyo" />
-        <param name="frame_id" type="string" value="base_laser_link" />
-        <param name="min_ang" type="double" value="-2.2689" />
-        <param name="max_ang" type="double" value="2.2689" />
-        <param name="skip" type="int" value="1" />
-        <param name="intensity" value="false" />
-      </node>
-  </group> -->
-
-  <!-- Tilt Laser -->
-  <!-- <group if="$(arg c2)">
-      <node  machine="c2" pkg="hokuyo_node" type="hokuyo_node" name="tilt_hokuyo_node" args="scan:=tilt_scan">
-        <param name="port" type="string" value="/etc/ros/sensors/tilt_hokuyo" />
-        <param name="frame_id" type="string" value="laser_tilt_link" />
-        <param name="min_ang" type="double" value="-0.829" />
-        <param name="max_ang" type="double" value="0.829" />
-        <param name="skip" type="int" value="1" />
-        <param name="intensity" value="true" />
-      </node>
-  </group> -->
-
   <!-- imu -->
   <node machine="c1" pkg="microstrain_3dmgx2_imu" type="imu_node" name="imu_node" output="screen">
     <remap from="imu" to="torso_lift_imu" />
@@ -125,27 +89,13 @@
   <!-- NTP monitoring script reports clock sync on diagnostics -->
   <node pkg="pr2_computer_monitor" name="ntp_c1" type="ntp_monitor.py" args="10.68.255.1 --offset-tolerance 50000 --diag-hostname=c1" machine="c1" />
 
-  <group if="$(arg c2)">
-      <node pkg="pr2_computer_monitor" name="ntp_c2" type="ntp_monitor.py" args="c1 --diag-hostname=c2" machine="c2"/>
-  </group>
-
   <!-- Disk usage monitoring script monitors HD temperature, usage on diagnostics -->
   <node pkg="pr2_computer_monitor" name="realtime_hd_monitor" type="hd_monitor.py" args="$(optenv HOME /home) --diag-hostname=c1" machine="c1"/>
-  <group if="$(arg c2)">
-      <node pkg="pr2_computer_monitor" name="two_hd_monitor" type="hd_monitor.py" args="--diag-hostname=c2" machine="c2"/>
-  </group>
 
   <!-- Monitor CPU temp, usage -->
   <node pkg="pr2_computer_monitor" name="realtime_cpu_monitor" type="cpu_monitor.py" args="--diag-hostname=c1" machine="c1" >
     <param name="check_core_temps" type="bool" value="False" />
   </node>
-
-  <group if="$(arg c2)">
-      <node pkg="pr2_computer_monitor" name="two_cpu_monitor" type="cpu_monitor.py" args="--diag-hostname=c2" machine="c2" >
-        <param name="check_core_temps" type="bool" value="False" />
-        <param name="enforce_clock_speed" type="bool" value="False" />
-      </node>
-   </group>
 
   <!-- Monitor Wifi/ddwrt -->
   <node pkg="pr2_computer_monitor" name="ddwrt_diag" type="wifi_monitor.py" machine="c1" />

--- a/pr2_bringup/pr2.launch
+++ b/pr2_bringup/pr2.launch
@@ -4,6 +4,11 @@
 
   <include file="$(find pr2_machine)/pr2.machine" />
 
+  <!-- New in Indigo, now c2's functionality is separated from c1s -->
+  <group if="$(arg c2)">
+    <include file="$(find pr2_bringup/pr2-c2.launch" />
+  </group>
+
   <!-- Remap diagnostics if we are pushed into a namespace. -->
   <remap from="/diagnostics" to="/$(optenv ROS_NAMESPACE /)/diagnostics" />
   <remap from="/diagnostics_agg" to="/$(optenv ROS_NAMESPACE /)/diagnostics_agg" />
@@ -38,7 +43,7 @@
   <node name="power_board" pkg="pr2_power_board" type="power_node2" args="--address=10.68.0.50" respawn="true"/>
 
   <!-- Battery Monitor -->
-  <group if="$(arg c2)"> 
+ <!--  <group if="$(arg c2)"> 
       <node machine="c2" pkg="ocean_battery_driver" type="ocean_server"  name="ocean_server" respawn="true">
         <param name="number_of_ports" type="int" value="4" />
         <param name="port0" type="string" value="/etc/ros/sensors/battery0" />
@@ -47,12 +52,12 @@
         <param name="port3" type="string" value="/etc/ros/sensors/battery3" />
         <param name="debug_level" type="int" value="0" />
       </node>
-  </group>
+  </group> -->
 
   <node pkg="power_monitor" type="power_monitor"  name="power_monitor" respawn="true"/>
   
   <!-- Base Laser -->
-  <group if="$(arg c2)">
+  <!-- <group if="$(arg c2)">
     <node machine="c2" pkg="hokuyo_node" type="hokuyo_node" name="base_hokuyo_node" args="scan:=base_scan">
         <param name="port" type="string" value="/etc/ros/sensors/base_hokuyo" />
         <param name="frame_id" type="string" value="base_laser_link" />
@@ -61,10 +66,10 @@
         <param name="skip" type="int" value="1" />
         <param name="intensity" value="false" />
       </node>
-  </group>
+  </group> -->
 
   <!-- Tilt Laser -->
-  <group if="$(arg c2)">
+  <!-- <group if="$(arg c2)">
       <node  machine="c2" pkg="hokuyo_node" type="hokuyo_node" name="tilt_hokuyo_node" args="scan:=tilt_scan">
         <param name="port" type="string" value="/etc/ros/sensors/tilt_hokuyo" />
         <param name="frame_id" type="string" value="laser_tilt_link" />
@@ -73,7 +78,7 @@
         <param name="skip" type="int" value="1" />
         <param name="intensity" value="true" />
       </node>
-  </group>
+  </group> -->
 
   <!-- imu -->
   <node machine="c1" pkg="microstrain_3dmgx2_imu" type="imu_node" name="imu_node" output="screen">
@@ -135,7 +140,7 @@
     <param name="check_core_temps" type="bool" value="False" />
   </node>
 
-   <group if="$(arg c2)">
+  <group if="$(arg c2)">
       <node pkg="pr2_computer_monitor" name="two_cpu_monitor" type="cpu_monitor.py" args="--diag-hostname=c2" machine="c2" >
         <param name="check_core_temps" type="bool" value="False" />
         <param name="enforce_clock_speed" type="bool" value="False" />

--- a/pr2_bringup/pr2.launch
+++ b/pr2_bringup/pr2.launch
@@ -6,7 +6,7 @@
 
   <!-- New in Indigo, now c2's functionality is separated from c1s -->
   <group if="$(arg c2)">
-    <include file="$(find pr2_bringup/pr2-c2.launch" />
+    <include file="$(find pr2_bringup)/pr2-c2.launch" />
   </group>
 
   <!-- Remap diagnostics if we are pushed into a namespace. -->


### PR DESCRIPTION
At the moment, the computer monitor code is disabled because it doesn't bringup.

The intent of this is to have seperate launch files for C1 and C2 code; in case you wish to launch only one or the other, for debugging, testing, or usability purposes, and with the intent to make the code more modular.

@wkentaro @archielee @k-okada @garaemon @pgrice 

Linked are those who might be interested in this stake/have thoughts about it. The usage is the same, however, now you can pass in c2:=false to prevent bringup of C2 launch file. By default, everything is brought up the same on the robot.
