### PR TITLE
Setting i_clamp_max and i_clamp_min explicitly

### DIFF
--- a/pr2_controller_configuration/pr2_arm_controllers.yaml
+++ b/pr2_controller_configuration/pr2_arm_controllers.yaml
@@ -3,6 +3,8 @@ shoulder_pan_gains: &shoulder_pan_gains
   d: 18.0
   i: 800.0
   i_clamp: 4.0
+  i_clamp_max: 4.0
+  i_clamp_min: -4.0
   mass: 3.3
   proxy:
     lambda: 3.0
@@ -15,6 +17,8 @@ shoulder_lift_gains: &shoulder_lift_gains
   d: 10.0
   i: 700.0
   i_clamp: 4.0
+  i_clamp_max: 4.0
+  i_clamp_min: -4.0
   mass: 2.0
   proxy:
     lambda: 3.0
@@ -27,30 +31,40 @@ upper_arm_roll_gains: &upper_arm_roll_gains
   i: 600.0
   d: 6.0
   i_clamp: 4.0
+  i_clamp_max: 4.0
+  i_clamp_min: -4.0
 
 elbow_flex_gains: &elbow_flex_gains
   p: 700.0
   i: 450.0
   d: 4.0
   i_clamp: 4.0
+  i_clamp_max: 4.0
+  i_clamp_min: -4.0
 
 forearm_roll_gains: &forearm_roll_gains
   p: 300.0
   i: 300.0
   d: 6.0
   i_clamp: 2.0
+  i_clamp_max: 2.0
+  i_clamp_min: -2.0
 
 wrist_flex_gains: &wrist_flex_gains
   p: 300.0
   i: 300.0
   d: 4.0
   i_clamp: 2.0
+  i_clamp_max: 2.0
+  i_clamp_min: -2.0
 
 wrist_roll_gains: &wrist_roll_gains
   p: 300.0
   i: 300.0
   d: 4.0
   i_clamp: 2.0
+  i_clamp_max: 2.0
+  i_clamp_min: -2.0
 
 r_arm_controller:
   type: "robot_mechanism_controllers/JointTrajectoryActionController"

--- a/pr2_controller_configuration/pr2_base_controller.yaml
+++ b/pr2_controller_configuration/pr2_base_controller.yaml
@@ -9,17 +9,23 @@ base_controller:
     d: 0.0
     i: 0.0
     i_clamp: 4.0
+    i_clamp_max: 4.0
+    i_clamp_min: -4.0
   caster_position_pid_gains: &caster_position_pid_gains
     p: 80.0
     d: 0.0
     i: 0.0
     i_clamp: 3.45
+    i_clamp_max: 3.45
+    i_clamp_min: -3.45
 
   wheel_pid_gains: &wheel_pid_gains
     p: 3.0
     d: 0.0
     i: 0.0
     i_clamp: 2.0
+    i_clamp_max: 2.0
+    i_clamp_min: -2.0
 
   fl_caster_l_wheel_joint:
    *wheel_pid_gains

--- a/pr2_controller_configuration/pr2_base_controller2.yaml
+++ b/pr2_controller_configuration/pr2_base_controller2.yaml
@@ -9,18 +9,24 @@ base_controller:
     d: 0.0
     i: 0.0
     i_clamp: 4.0
+    i_clamp_max: 4.0
+    i_clamp_min: -4.0
 
   f_caster_position_pid_gains: &f_caster_position_pid_gains
     p: 100.0
     d: 8.0
     i: 0.0
     i_clamp: 0.0
+    i_clamp_max: 0.0
+    i_clamp_min: -0.0
 
   b_caster_velocity_pid_gains: &b_caster_velocity_pid_gains
     p: 8.0
     d: 0.0
     i: 0.0
     i_clamp: 4.0
+    i_clamp_max: 4.0
+    i_clamp_min: -4.0
 
   b_caster_position_pid_gains: &b_caster_position_pid_gains
     p: 100.0
@@ -33,6 +39,8 @@ base_controller:
     d: 5.0
     i: 0.0
     i_clamp: 0.0
+    i_clamp_max: 0.0
+    i_clamp_min: -0.0
 
   fl_caster_l_wheel_joint:
    *wheel_pid_gains

--- a/pr2_controller_configuration/pr2_calibration_controllers.yaml
+++ b/pr2_controller_configuration/pr2_calibration_controllers.yaml
@@ -9,6 +9,8 @@ cal_torso_lift:
     d: 10000
     i: 0
     i_clamp: 12000
+    i_clamp_max: 12000
+    i_clamp_min: -12000
 cal_r_shoulder_pan:
   type: pr2_calibration_controllers/JointCalibrationController
   joint: r_shoulder_pan_joint
@@ -20,6 +22,8 @@ cal_r_shoulder_pan:
     i: 0.5
     d: 0
     i_clamp: 1.0
+    i_clamp_max: 1.0
+    i_clamp_min: -1.0
 cal_l_shoulder_pan:
   type: pr2_calibration_controllers/JointCalibrationController
   joint: l_shoulder_pan_joint
@@ -31,6 +35,8 @@ cal_l_shoulder_pan:
     i: 0.5
     d: 0
     i_clamp: 1.0
+    i_clamp_max: 1.0
+    i_clamp_min: -1.0
 cal_r_shoulder_lift:
   type: pr2_calibration_controllers/JointCalibrationController
   joint: r_shoulder_lift_joint
@@ -42,6 +48,8 @@ cal_r_shoulder_lift:
     i: 1.0
     d: 0
     i_clamp: 6
+    i_clamp_max: 6
+    i_clamp_min: -6
 cal_l_shoulder_lift:
   type: pr2_calibration_controllers/JointCalibrationController
   joint: l_shoulder_lift_joint
@@ -53,6 +61,8 @@ cal_l_shoulder_lift:
     i: 1.0
     d: 0
     i_clamp: 6
+    i_clamp_max: 6
+    i_clamp_min: -6
 cal_r_upper_arm_roll:
   type: pr2_calibration_controllers/JointCalibrationController
   joint: r_upper_arm_roll_joint
@@ -64,6 +74,8 @@ cal_r_upper_arm_roll:
     i: 0.2
     d: 0
     i_clamp: 2
+    i_clamp_max: 2
+    i_clamp_min: -2
 cal_l_upper_arm_roll:
   type: pr2_calibration_controllers/JointCalibrationController
   joint: l_upper_arm_roll_joint
@@ -75,6 +87,8 @@ cal_l_upper_arm_roll:
     i: 0.2
     d: 0
     i_clamp: 2
+    i_clamp_max: 2
+    i_clamp_min: -2
 cal_r_elbow_flex:
   type: pr2_calibration_controllers/JointCalibrationController
   joint: r_elbow_flex_joint
@@ -86,6 +100,8 @@ cal_r_elbow_flex:
     i: 0.2
     d: 0
     i_clamp: 1
+    i_clamp_max: 1
+    i_clamp_min: -1
 cal_l_elbow_flex:
   type: pr2_calibration_controllers/JointCalibrationController
   joint: l_elbow_flex_joint
@@ -97,6 +113,8 @@ cal_l_elbow_flex:
     i: 0.2
     d: 0
     i_clamp: 1
+    i_clamp_max: 1
+    i_clamp_min: -1
 
 cal_r_forearm_roll:
   type: pr2_calibration_controllers/JointCalibrationController
@@ -109,6 +127,8 @@ cal_r_forearm_roll:
     i: 0.0
     d: 0.0
     i_clamp: 0.0
+    i_clamp_max: 0.0
+    i_clamp_min: -0.0
 cal_r_wrist:
   type: pr2_calibration_controllers/WristCalibrationController
   actuator_l: r_wrist_l_motor
@@ -123,6 +143,8 @@ cal_r_wrist:
     d: 0.0
     i: 0.2
     i_clamp: 2.0
+    i_clamp_max: 2.0
+    i_clamp_min: -2.0
 cal_r_gripper:
   type: pr2_calibration_controllers/GripperCalibrationController
   actuator: r_gripper_motor
@@ -138,7 +160,8 @@ cal_r_gripper:
     d: 0
     i: 10000.0
     i_clamp: 15.0
-
+    i_clamp_max: 15.0
+    i_clamp_min: -15.0
 
 cal_l_forearm_roll:
   type: pr2_calibration_controllers/JointCalibrationController
@@ -151,6 +174,8 @@ cal_l_forearm_roll:
     i: 0.0
     d: 0.0
     i_clamp: 0.0
+    i_clamp_max: 0.0
+    i_clamp_min: -0.0
 cal_l_wrist:
   type: pr2_calibration_controllers/WristCalibrationController
   actuator_l: l_wrist_l_motor
@@ -165,6 +190,8 @@ cal_l_wrist:
     d: 0.0
     i: 0.2
     i_clamp: 2.0
+    i_clamp_max: 2.0
+    i_clamp_min: -2.0
 cal_l_gripper:
   type: pr2_calibration_controllers/GripperCalibrationController
   actuator: l_gripper_motor
@@ -180,7 +207,8 @@ cal_l_gripper:
     d: 0
     i: 10000.0
     i_clamp: 15.0
-
+    i_clamp_max: 15.0
+    i_clamp_min: -15.0
 
 
 cal_laser_tilt:
@@ -194,6 +222,8 @@ cal_laser_tilt:
     d: 0
     i: 0.1
     i_clamp: 1.0
+    i_clamp_max: 1.0
+    i_clamp_min: -1.0
 
 caster_calibration: &caster_calibration
   caster_pid: {p: 6.0}
@@ -255,6 +285,8 @@ cal_head_pan:
     d: 0
     i: 0.0
     i_clamp: 1.0
+    i_clamp_max: 1.0
+    i_clamp_min: -1.0
 cal_head_tilt:
   type: pr2_calibration_controllers/JointCalibrationController
   actuator: head_tilt_motor
@@ -266,3 +298,5 @@ cal_head_tilt:
     d: 0
     i: 5.0
     i_clamp: 1.0
+    i_clamp_max: 1.0
+    i_clamp_min: -1.0

--- a/pr2_controller_configuration/pr2_head_controller.yaml
+++ b/pr2_controller_configuration/pr2_head_controller.yaml
@@ -7,8 +7,12 @@ head_traj_controller:
       i: 12.0
       d: 2.0
       i_clamp: 0.5 
+      i_clamp_max: 0.5 
+      i_clamp_min: -0.5 
     head_tilt_joint:
       p: 100.0
       i: 2.0
       d: 3.0
       i_clamp: 0.1 
+      i_clamp_max: 0.1 
+      i_clamp_min: -0.1 

--- a/pr2_controller_configuration/pr2_joint_position_controllers.yaml
+++ b/pr2_controller_configuration/pr2_joint_position_controllers.yaml
@@ -6,6 +6,8 @@ r_shoulder_pan_position_controller:
     d: 18.0
     i: 800.0
     i_clamp: 4.0
+    i_clamp_max: 4.0
+    i_clamp_min: -4.0
 r_shoulder_lift_position_controller:
   type: robot_mechanism_controllers/JointPositionController
   joint: r_shoulder_lift_joint
@@ -14,6 +16,8 @@ r_shoulder_lift_position_controller:
     d: 10.0
     i: 700.0
     i_clamp: 4.0
+    i_clamp_max: 4.0
+    i_clamp_min: -4.0
 r_upper_arm_roll_position_controller:
   type: robot_mechanism_controllers/JointPositionController
   joint: r_upper_arm_roll_joint
@@ -22,6 +26,8 @@ r_upper_arm_roll_position_controller:
     d: 6.0
     i: 600.0
     i_clamp: 4.0
+    i_clamp_max: 4.0
+    i_clamp_min: -4.0
 r_elbow_flex_position_controller:
   type: robot_mechanism_controllers/JointPositionController
   joint: r_elbow_flex_joint
@@ -30,6 +36,8 @@ r_elbow_flex_position_controller:
     d: 4.0
     i: 450.0
     i_clamp: 4.0
+    i_clamp_max: 4.0
+    i_clamp_min: -4.0
 r_forearm_roll_position_controller:
   type: robot_mechanism_controllers/JointPositionController
   joint: r_forearm_roll_joint
@@ -38,6 +46,8 @@ r_forearm_roll_position_controller:
     d: 6.0
     i: 300.0
     i_clamp: 2.0
+    i_clamp_max: 2.0
+    i_clamp_min: -2.0
 r_wrist_flex_position_controller:
   type: robot_mechanism_controllers/JointPositionController
   joint: r_wrist_flex_joint
@@ -46,6 +56,8 @@ r_wrist_flex_position_controller:
     d: 4.0
     i: 300.0
     i_clamp: 2.0
+    i_clamp_max: 2.0
+    i_clamp_min: -2.0
 r_wrist_roll_position_controller:
   type: robot_mechanism_controllers/JointPositionController
   joint: r_wrist_roll_joint
@@ -54,6 +66,8 @@ r_wrist_roll_position_controller:
     d: 4.0
     i: 300.0
     i_clamp: 2.0
+    i_clamp_max: 2.0
+    i_clamp_min: -2.0
 r_gripper_position_controller:
   type: robot_mechanism_controllers/JointPositionController
   joint: r_gripper_joint
@@ -62,6 +76,8 @@ r_gripper_position_controller:
     d: 1000.0
     i: 0.0
     i_clamp: 0.0
+    i_clamp_max: 0.0
+    i_clamp_min: -0.0
 
 l_shoulder_pan_position_controller:
   type: robot_mechanism_controllers/JointPositionController
@@ -104,3 +120,5 @@ torso_lift_position_controller:
     d: 1000000.0
     i: 0.0
     i_clamp: 0.0
+    i_clamp_max: 0.0
+    i_clamp_min: -0.0

--- a/pr2_controller_configuration/pr2_joint_velocity_controllers.yaml
+++ b/pr2_controller_configuration/pr2_joint_velocity_controllers.yaml
@@ -6,6 +6,8 @@ r_shoulder_pan_velocity_controller:
     i: 4.67
     d: 0.0
     i_clamp: 100.0
+    i_clamp_max: 100.0
+    i_clamp_min: -100.0
 r_shoulder_lift_velocity_controller:
   type: robot_mechanism_controllers/JointVelocityController
   joint: r_shoulder_lift_joint
@@ -14,6 +16,8 @@ r_shoulder_lift_velocity_controller:
     i: 5.67
     d: 0
     i_clamp: 100.0
+    i_clamp_max: 100.0
+    i_clamp_min: -100.0
 r_upper_arm_roll_velocity_controller:
   type: robot_mechanism_controllers/JointVelocityController
   joint: r_upper_arm_roll_joint
@@ -22,6 +26,8 @@ r_upper_arm_roll_velocity_controller:
     i: 42.9
     d: 0
     i_clamp: 100.0
+    i_clamp_max: 100.0
+    i_clamp_min: -100.0
 r_elbow_flex_velocity_controller:
   type: robot_mechanism_controllers/JointVelocityController
   joint: r_elbow_flex_joint
@@ -30,6 +36,8 @@ r_elbow_flex_velocity_controller:
     i: 20.0
     d: 0
     i_clamp: 100.0
+    i_clamp_max: 100.0
+    i_clamp_min: -100.0
 r_forearm_roll_velocity_controller:
   type: robot_mechanism_controllers/JointVelocityController
   joint: r_forearm_roll_joint
@@ -38,6 +46,8 @@ r_forearm_roll_velocity_controller:
     i: 15.0
     d: 0
     i_clamp: 100.0
+    i_clamp_max: 100.0
+    i_clamp_min: -100.0
 r_wrist_flex_velocity_controller:
   type: robot_mechanism_controllers/JointVelocityController
   joint: r_wrist_flex_joint
@@ -46,6 +56,8 @@ r_wrist_flex_velocity_controller:
     i: 25.0
     d: 0
     i_clamp: 100.0
+    i_clamp_max: 100.0
+    i_clamp_min: -100.0
 r_wrist_roll_velocity_controller:
   type: robot_mechanism_controllers/JointVelocityController
   joint: r_wrist_roll_joint
@@ -54,6 +66,8 @@ r_wrist_roll_velocity_controller:
     i: 25.0
     d: 0
     i_clamp: 100.0
+    i_clamp_max: 100.0
+    i_clamp_min: -100.0
 
 
 
@@ -95,6 +109,8 @@ torso_lift_velocity_controller:
     d: 0.0
     i: 1000.0
     i_clamp: 1200.0
+    i_clamp_max: 1200.0
+    i_clamp_min: -1200.0
 
 
 

--- a/pr2_controller_configuration/pr2_laser_tilt_controller.yaml
+++ b/pr2_controller_configuration/pr2_laser_tilt_controller.yaml
@@ -6,6 +6,8 @@ laser_tilt_controller:
     i: 0.1
     d: 0.2
     i_clamp: 0.5
+    i_clamp_max: 0.5
+    i_clamp_min: -0.5
   velocity_filter:
     - name: low_pass
       type: filters/TransferFunctionFilterDouble

--- a/pr2_controller_configuration/pr2_torso_controller.yaml
+++ b/pr2_controller_configuration/pr2_torso_controller.yaml
@@ -8,6 +8,8 @@ torso_controller:
       d: 1000000.0
       i: 0.0
       i_clamp: 0.0
+      i_clamp_max: 0.0
+      i_clamp_min: -0.0
   position_joint_action_node:
     joint: torso_lift_joint
     goal_threshold: 0.01


### PR DESCRIPTION
Added i_clamp_max and i_clamp_min to all yaml files where applicable (anything using control_toolbox::PID), keeping the same values (+/- for max/min).  Tested briefly on our PR2, no errors, and everything seems to be running normally (i.e. nothing seems broken).  This should not change default behavior at all, but copies of this file will load updated parameters properly.
