### PR TITLE
Fix Kinect2 calibration data path to match NUC's installed directory names

### DIFF
--- a/pr2_bringup/config/kinect2_bridge.launch
+++ b/pr2_bringup/config/kinect2_bridge.launch
@@ -32,7 +32,7 @@
     <param name="publish_tf"        type="bool"   value="$(arg publish_tf)"/>
     <param name="base_name_tf"      type="str"    value="$(arg base_name_tf)"/>
     <param name="fps_limit"         type="double" value="$(arg fps_limit)"/>
-    <param name="calib_path"        type="str"    value="/home/pr2-head/kinect2_ws/src/iai_kinect2/kinect2_bridge/data/"/>
+    <param name="calib_path"        type="str"    value="/home/pr2-head/kinect_ws/src/iai_kinect2/kinect2_bridge/data/"/>
     <param name="use_png"           type="bool"   value="$(arg use_png)"/>
     <param name="jpeg_quality"      type="int"    value="$(arg jpeg_quality)"/>
     <param name="png_level"         type="int"    value="$(arg png_level)"/>


### PR DESCRIPTION
The NUCs for the head-mounted kinect2's in Indigo come installed with code in the kinect_ws directory, but the pr2_bringup sets the calibration data path to include ~/kinect2_ws, so calibration data is not found, even when placed in the correct folder under kinect2_bridge.  This changes the path in pr2_bringup, rather than changing the directory name on the NUC, to solve the problem.
