### PR TITLE
calibrate_pr2: intercept and print exception

### DIFF
--- a/pr2_bringup/scripts/calibrate_pr2.py
+++ b/pr2_bringup/scripts/calibrate_pr2.py
@@ -415,7 +415,9 @@ def main():
         joints_status = True
         status.publish()
 
-        
+    except Exception as e:
+        rospy.logerr("Calibration failed: %s" % str(e))
+
     finally:
         rospy.loginfo("Bringing down calibration node")
 


### PR DESCRIPTION
Exceptions were silently ignored before.

This came up when I played around with the calibration script and helps debugging.
It does not trigger with normal usage.
