### PR TITLE
pr2_bringup: test launch files

### DIFF
--- a/pr2_bringup/CMakeLists.txt
+++ b/pr2_bringup/CMakeLists.txt
@@ -33,10 +33,9 @@ if (CATKIN_ENABLE_TESTING)
   find_package(roslaunch REQUIRED)
   # Tests that PR2 diagnostic analyzers configuration loads
   add_rostest(test/pr2_analyzers_load_test.launch)
-  set(roslaunch_check_script ${PROJECT_SOURCE_DIR}/test/roslaunch-check)
-  roslaunch_add_file_check(pr2.launch ROS_ENV_LOADER=/opt/ros/$ENV{ROS_DISTRO}/env.sh)
-  roslaunch_add_file_check(pr2-c2.launch)
+  # Disable because pr2.launch needs to resolve c1/c2 hostname
+  # roslaunch_add_file_check(pr2.launch ROS_ENV_LOADER=/opt/ros/$ENV{ROS_DISTRO}/env.sh)
+  # roslaunch_add_file_check(pr2-c2.launch)
   roslaunch_add_file_check(pr2_recalibrate.launch)
-  set(roslaunch_check_script ${roslaunch_DIR}/../scripts/roslaunch-check)
 endif()
 

--- a/pr2_bringup/CMakeLists.txt
+++ b/pr2_bringup/CMakeLists.txt
@@ -27,3 +27,16 @@ install(FILES
    pr2_recalibrate.launch
    pr2-c2.launch
    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+
+if (CATKIN_ENABLE_TESTING)
+  find_package(rostest REQUIRED)
+  find_package(roslaunch REQUIRED)
+  # Tests that PR2 diagnostic analyzers configuration loads
+  add_rostest(test/pr2_analyzers_load_test.launch)
+  set(roslaunch_check_script ${PROJECT_SOURCE_DIR}/test/roslaunch-check)
+  roslaunch_add_file_check(pr2.launch ROS_ENV_LOADER=/opt/ros/$ENV{ROS_DISTRO}/env.sh)
+  roslaunch_add_file_check(pr2-c2.launch)
+  roslaunch_add_file_check(pr2_recalibrate.launch)
+  set(roslaunch_check_script ${roslaunch_DIR}/../scripts/roslaunch-check)
+endif()
+

--- a/pr2_bringup/package.xml
+++ b/pr2_bringup/package.xml
@@ -12,7 +12,9 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <!-- for testing -->
   <build_depend>rostest</build_depend>
+  <build_depend>roslaunch</build_depend>
 
   <run_depend>pr2_description</run_depend>
   <run_depend>pr2_machine</run_depend>
@@ -47,4 +49,5 @@
   <run_depend>pr2_computer_monitor</run_depend>
   <run_depend>diagnostic_aggregator</run_depend>
   <run_depend>pr2_dashboard_aggregator</run_depend>
+  <run_depend>imu_monitor</run_depend>
 </package>


### PR DESCRIPTION
This PR adds a test script that validates the default launch files for bringing up PR2 robot.
