### PR TITLE
Param names changed between urg_node and hokuyo_node

### DIFF
--- a/pr2_bringup/pr2-c2.launch
+++ b/pr2_bringup/pr2-c2.launch
@@ -12,22 +12,20 @@
   
       <!-- Base Laser -->
       <node machine="c2" pkg="urg_node" type="urg_node" name="base_hokuyo_node" args="scan:=base_scan">
-        <param name="port" type="string" value="/etc/ros/sensors/base_hokuyo" />
+        <param name="serial_port" type="string" value="/etc/ros/sensors/base_hokuyo" />
         <param name="frame_id" type="string" value="base_laser_link" />
-        <param name="min_ang" type="double" value="-2.2689" />
-        <param name="max_ang" type="double" value="2.2689" />
-        <param name="skip" type="int" value="1" />
-        <param name="intensity" value="false" />
+        <param name="angle_min" type="double" value="-2.2689" />
+        <param name="angle_max" type="double" value="2.2689" />
+        <param name="publish_intensity" value="false" />
       </node>
  
       <!-- Tilt laser -->
       <node  machine="c2" pkg="urg_node" type="urg_node" name="tilt_hokuyo_node" args="scan:=tilt_scan">
-        <param name="port" type="string" value="/etc/ros/sensors/tilt_hokuyo" />
+        <param name="serial_port" type="string" value="/etc/ros/sensors/tilt_hokuyo" />
         <param name="frame_id" type="string" value="laser_tilt_link" />
-        <param name="min_ang" type="double" value="-0.829" />
-        <param name="max_ang" type="double" value="0.829" />
-        <param name="skip" type="int" value="1" />
-        <param name="intensity" value="true" />
+        <param name="angle_min" type="double" value="-0.829" />
+        <param name="angle_max" type="double" value="0.829" />
+        <param name="publish_intensity" value="true" />
       </node> 
 
 


### PR DESCRIPTION
The new urg_node package is used for the laser scanners in kinetic, but the parameter names are still the one of the hokuyo_node package.