### PR TITLE
decode byte to str for isnumeric

### DIFF
--- a/pr2_computer_monitor/scripts/hd_monitor.py
+++ b/pr2_computer_monitor/scripts/hd_monitor.py
@@ -201,6 +201,8 @@ class hd_monitor():
 
         for index in range(0, len(drives)):
             temp = temps[index]
+            if type(temp) == bytes:
+                temp = temp.decode('utf-8')
             
             if not temp.isnumeric() and drives[index] not in REMOVABLE:
                 temp_level = DiagnosticStatus.ERROR


### PR DESCRIPTION
this change is needed for noetic.
temp is sometimes `bytes` in `python3`, so this PR convert it to `string` for `isnumeric` method.