### PR TITLE
Import setup from setuptools instead of distutils.core

### DIFF
--- a/pr2_camera_synchronizer/package.xml
+++ b/pr2_camera_synchronizer/package.xml
@@ -26,6 +26,8 @@
   <author>Blaise Gassend</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>rostest</build_depend>

--- a/pr2_camera_synchronizer/package.xml
+++ b/pr2_camera_synchronizer/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="3">
   <name>pr2_camera_synchronizer</name>
   <version>1.6.32</version>
   <description>
@@ -30,9 +30,9 @@
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>rostest</build_depend>
 
-  <run_depend>ethercat_trigger_controllers</run_depend>
-  <run_depend>rospy</run_depend>
-  <run_depend>dynamic_reconfigure</run_depend>
-  <run_depend>wge100_camera</run_depend>
-  <run_depend>diagnostic_msgs</run_depend>
+  <exec_depend>ethercat_trigger_controllers</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>dynamic_reconfigure</exec_depend>
+  <exec_depend>wge100_camera</exec_depend>
+  <exec_depend>diagnostic_msgs</exec_depend>
 </package>

--- a/pr2_camera_synchronizer/setup.py
+++ b/pr2_camera_synchronizer/setup.py
@@ -1,6 +1,6 @@
 ## ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml

--- a/pr2_computer_monitor/package.xml
+++ b/pr2_computer_monitor/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="3">
   <name>pr2_computer_monitor</name>
   <version>1.6.32</version>
   <description>Monitors the computer's processor and hard drives of the PR2 and publishes data to diagnostics.</description>
@@ -18,11 +18,11 @@
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
 
-  <run_depend>diagnostic_msgs</run_depend>
-  <run_depend>rospy</run_depend>
-  <run_depend>pr2_msgs</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>std_msgs</run_depend>
+  <exec_depend>diagnostic_msgs</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>pr2_msgs</exec_depend>
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
 
 
 

--- a/pr2_computer_monitor/package.xml
+++ b/pr2_computer_monitor/package.xml
@@ -12,6 +12,8 @@
   <author>Kevin Watts (watts@willowgarage.com)</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <build_depend>diagnostic_msgs</build_depend>
   <build_depend>pr2_msgs</build_depend>

--- a/pr2_computer_monitor/setup.py
+++ b/pr2_computer_monitor/setup.py
@@ -1,6 +1,6 @@
 ## ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml


### PR DESCRIPTION
Recently users of newer distributions who build Noetic from source noticed issues when importing setup from distutils.core.
This problem was discussed on [Discourse](https://discourse.ros.org/t/ros-1-and-python-3-10s-deprecation-of-distutils-core/29834), and we hope that we can make the needed updates to Noetic to allow for future builds from source of Noetic.
As a first step, this PR introduces changes from the [Noetic Migration Guide](https://wiki.ros.org/noetic/Migration#Setuptools_instead_of_Distutils) that addresses the change to the setuptools module instead of distutils.core and the corresponding buildtool_depend tags for python 2&3.